### PR TITLE
feat: Reuse attempted username from previous authenticator

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
@@ -35,6 +35,9 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
 
         if (context.loginPage().shouldByPass()) {
             String loginHint = context.loginHint().getFromSession();
+            if (loginHint == null) {
+                loginHint = authenticationFlowContext.getAuthenticationSession().getAuthNote(ATTEMPTED_USERNAME);
+            }
             String username = setUserInContext(authenticationFlowContext, loginHint);
             final List<IdentityProviderModel> homeIdps = context.discoverer().discoverForUser(username);
             if (!homeIdps.isEmpty()) {


### PR DESCRIPTION
Allows to use an attempted username from a previous authenticator if config option `bypassLoginPage` is switched on and no `login_hint` param is present.

Closes #96