### PR TITLE
Update Keycloak dependencies to 22.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,8 +38,8 @@ body:
     label: Version
     description: |
       examples:
-        - **Keycloak**: 21.1.2
-        - **This extension**:  21.2.0
+        - **Keycloak**: 22.0.0
+        - **This extension**:  22.0.0
     value: |
         - Keycloak:
         - This extension:

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        keycloak_version: [ 21.0.2, 21.1.0, 21.1.2, latest ]
+        keycloak_version: [ 22.0.0, latest ]
         experimental: [false]
         include:
             - keycloak_version: nightly

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a simple Keycloak authenticator to redirect users to their home identity provider during login.
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/sventorben/keycloak-home-idp-discovery?sort=semver)
-![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-21.1.2-blue)
+![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-22.0.0-blue)
 ![GitHub Release Date](https://img.shields.io/github/release-date-pre/sventorben/keycloak-home-idp-discovery)
 ![Github Last Commit](https://img.shields.io/github/last-commit/sventorben/keycloak-home-idp-discovery)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   keycloak:
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:21.1.2
+    image: quay.io/keycloak/keycloak:22.0.0
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ nav_order: 1
 This is a simple Keycloak authenticator to redirect users to their home identity provider during login.
 
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/sventorben/keycloak-home-idp-discovery?sort=semver)
-![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-21.1.2-blue)
+![Keycloak Dependency Version](https://img.shields.io/badge/Keycloak-22.0.0-blue)
 ![GitHub Release Date](https://img.shields.io/github/release-date-pre/sventorben/keycloak-home-idp-discovery)
 ![Github Last Commit](https://img.shields.io/github/last-commit/sventorben/keycloak-home-idp-discovery)
 
@@ -18,7 +18,7 @@ This is a simple Keycloak authenticator to redirect users to their home identity
 
 ## What is it good for?
 
-When a federated user wants to login via Keycloak, Keycloak will present a username/password form and a list of configured identity providers to the user. The user needs to choose an identity provider to get redirected.
+When a federated user wants to log in via Keycloak, Keycloak will present a username/password form and a list of configured identity providers to the user. The user needs to choose an identity provider to get redirected.
 This authenticator allows to skip the step of selecting an identity provider.
 
 ## How does it work?

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.sventorben.keycloak</groupId>
     <artifactId>keycloak-home-idp-discovery</artifactId>
-    <version>21.3.1-SNAPSHOT</version>
+    <version>22.0.0-SNAPSHOT</version>
 
     <name>Keycloak: Home IdP Discovery</name>
     <description>A Keycloak authenticator to redirect users to their home IdP</description>
@@ -51,7 +51,7 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <!-- For compilation -->
-        <version.keycloak>21.1.2</version.keycloak>
+        <version.keycloak>22.0.0</version.keycloak>
 
         <!-- For compatibility tests -->
         <keycloak.version>${version.keycloak}</keycloak.version>
@@ -156,27 +156,6 @@
     <dependencyManagement>
         <dependencies>
 
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-client</artifactId>
-                <version>4.7.4.Final</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jackson2-provider</artifactId>
-                <version>4.7.4.Final</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-jaxb-provider</artifactId>
-                <version>4.7.4.Final</version>
-                <scope>test</scope>
-            </dependency>
-
             <!-- Tests -->
             <dependency>
                 <groupId>org.junit</groupId>
@@ -273,7 +252,7 @@
         <dependency>
             <groupId>com.github.dasniko</groupId>
             <artifactId>testcontainers-keycloak</artifactId>
-            <version>2.5.0</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/AuthenticationChallenge.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/AuthenticationChallenge.java
@@ -1,12 +1,12 @@
 package de.sventorben.keycloak.authentication.hidpd;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.services.managers.AuthenticationManager;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import java.util.List;
 
 final class AuthenticationChallenge {

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/BaseUriLoginFormsProvider.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/BaseUriLoginFormsProvider.java
@@ -1,10 +1,10 @@
 package de.sventorben.keycloak.authentication.hidpd;
 
+import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.forms.login.freemarker.FreeMarkerLoginFormsProvider;
 import org.keycloak.services.resources.LoginActionsService;
 
-import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 /**

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
@@ -1,5 +1,7 @@
 package de.sventorben.keycloak.authentication.hidpd;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -15,8 +17,6 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.managers.AuthenticationManager;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static org.keycloak.protocol.oidc.OIDCLoginProtocol.LOGIN_HINT_PARAM;

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/LoginForm.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/LoginForm.java
@@ -1,12 +1,12 @@
 package de.sventorben.keycloak.authentication.hidpd;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
 import org.keycloak.models.IdentityProviderModel;
 
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/LoginPage.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/LoginPage.java
@@ -2,18 +2,12 @@ package de.sventorben.keycloak.authentication.hidpd;
 
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 import java.util.Set;
 
-import static org.keycloak.protocol.oidc.OIDCLoginProtocol.PROMPT_PARAM;
-import static org.keycloak.protocol.oidc.OIDCLoginProtocol.PROMPT_VALUE_CONSENT;
-import static org.keycloak.protocol.oidc.OIDCLoginProtocol.PROMPT_VALUE_LOGIN;
-import static org.keycloak.protocol.oidc.OIDCLoginProtocol.PROMPT_VALUE_SELECT_ACCOUNT;
+import static org.keycloak.protocol.oidc.OIDCLoginProtocol.*;
 import static org.keycloak.protocol.saml.SamlProtocol.SAML_FORCEAUTHN_REQUIREMENT;
 import static org.keycloak.protocol.saml.SamlProtocol.SAML_LOGIN_REQUEST_FORCEAUTHN;
 

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/Redirector.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/Redirector.java
@@ -1,5 +1,6 @@
 package de.sventorben.keycloak.authentication.hidpd;
 
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.broker.provider.AuthenticationRequest;
@@ -10,12 +11,9 @@ import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakUriInfo;
 import org.keycloak.models.RealmModel;
-import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.Urls;
 import org.keycloak.services.managers.ClientSessionCode;
 import org.keycloak.sessions.AuthenticationSessionModel;
-
-import javax.ws.rs.core.Response;
 
 import static org.keycloak.services.resources.IdentityBrokerService.getIdentityProviderFactory;
 

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/RememberMe.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/RememberMe.java
@@ -1,11 +1,10 @@
 package de.sventorben.keycloak.authentication.hidpd;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.events.Details;
 import org.keycloak.models.RealmModel;
 import org.keycloak.services.managers.AuthenticationManager;
-
-import javax.ws.rs.core.MultivaluedMap;
 
 final class RememberMe {
 

--- a/src/test/java/de/sventorben/keycloak/authentication/AuthenticatorConfig.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/AuthenticatorConfig.java
@@ -1,11 +1,11 @@
 package de.sventorben.keycloak.authentication;
 
+import jakarta.ws.rs.core.Response;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.AuthenticationManagementResource;
 import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
 
-import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -95,8 +95,10 @@ final class AuthenticatorConfig {
             if (authenticationConfigId == null) {
                 authenticatorConfig = new AuthenticatorConfigRepresentation();
                 authenticatorConfig.setAlias(authenticatorConfigAlias);
-                Response response = flows.newExecutionConfig(execution.getId(), authenticatorConfig);
-                String location = response.getHeaderString("Location");
+                String location;
+                try (Response response = flows.newExecutionConfig(execution.getId(), authenticatorConfig)) {
+                    location = response.getHeaderString("Location");
+                }
                 authenticationConfigId = location.substring(location.lastIndexOf("/") + 1);
             } else {
                 authenticatorConfig = flows.getAuthenticatorConfig(authenticationConfigId);

--- a/src/test/java/de/sventorben/keycloak/authentication/hidpd/LoginPageTest.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/hidpd/LoginPageTest.java
@@ -13,9 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.keycloak.protocol.oidc.OIDCLoginProtocol.PROMPT_PARAM;
 import static org.keycloak.protocol.oidc.OIDCLoginProtocol.PROMPT_VALUE_CONSENT;


### PR DESCRIPTION
This includes breaking changes due to transition from Java EE to Jakarta EE. As part of upgrading to Quarkus 3.x Keycloak migrated its codebase from Java EE to the successor Jakarta EE. This updates reflects the changes.

For details please see [this blog post](https://www.keycloak.org/2023/07/keycloak-2200-released.html)