### PR TITLE
Remove home-idp-discovery theme selection for admin console

### DIFF
--- a/src/main/resources/META-INF/keycloak-themes.json
+++ b/src/main/resources/META-INF/keycloak-themes.json
@@ -1,8 +1,0 @@
-{
-    "themes": [
-        {
-            "name" : "home-idp-discovery",
-            "types": [ "admin" ]
-        }
-    ]
-}


### PR DESCRIPTION
The theme is no longer available for a while now and the configuration was only here to support certain update scenarios where the theme was still configured.

Make sure the theme is no longer configured/selected for the admin console in any realm, before upgrading to this version.

Closes #225