### PR TITLE
fix: do not leak existing username/email on regular sign in form

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
@@ -80,6 +80,9 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
 
         final List<IdentityProviderModel> homeIdps = context.discoverer().discoverForUser(username);
         if (homeIdps.isEmpty()) {
+            LOG.debug("Clearing user from context");
+            // back to the initial state to avoid leaking valid username/emails
+            authenticationFlowContext.clearUser();
             authenticationFlowContext.attempted();
         } else {
             RememberMe rememberMe = context.rememberMe();


### PR DESCRIPTION
The HomeIdpDiscoveryAuthenticator sets the user in the auth context in order to function properly. However, it doesn't clear it in case it "fails", meaning the next authenticator will be aware of the user.

This is problematic when a username/email doesn't match an idp, and keycloak redirects to the username password form. Indeed, the latter behaves differently whether the user is known or not (showing/hiding the email field). Without this clear, we basically leak information on which user exists.

This fix should ensure the username/password form always shows the email field.

Closes #251 