### PR TITLE
Do not leak existing username/email on regular sign in form

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpAuthenticationFlowContext.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpAuthenticationFlowContext.java
@@ -8,6 +8,7 @@ final class HomeIdpAuthenticationFlowContext {
     private HomeIdpDiscoveryConfig config;
     private LoginPage loginPage;
     private LoginHint loginHint;
+    private Users users;
     private HomeIdpDiscoverer discoverer;
     private RememberMe rememberMe;
     private AuthenticationChallenge authenticationChallenge;
@@ -35,14 +36,21 @@ final class HomeIdpAuthenticationFlowContext {
 
     LoginHint loginHint() {
         if (loginHint == null) {
-            loginHint = new LoginHint(context);
+            loginHint = new LoginHint(context, users());
         }
         return loginHint;
     }
 
+    Users users() {
+        if (users == null) {
+            users = new Users(context);
+        }
+        return users;
+    }
+
     HomeIdpDiscoverer discoverer() {
         if (discoverer == null) {
-            discoverer = new HomeIdpDiscoverer(context);
+            discoverer = new HomeIdpDiscoverer(context, users());
         }
         return  discoverer;
     }

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoverer.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoverer.java
@@ -2,11 +2,7 @@ package de.sventorben.keycloak.authentication.hidpd;
 
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.models.AuthenticatorConfigModel;
-import org.keycloak.models.FederatedIdentityModel;
-import org.keycloak.models.IdentityProviderModel;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.UserModel;
+import org.keycloak.models.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,14 +15,16 @@ final class HomeIdpDiscoverer {
 
     private static final Logger LOG = Logger.getLogger(HomeIdpDiscoverer.class);
 
+    private final Users users;
     private final DomainExtractor domainExtractor;
     private final AuthenticationFlowContext context;
 
-    HomeIdpDiscoverer(AuthenticationFlowContext context) {
-        this(new DomainExtractor(new HomeIdpDiscoveryConfig(context.getAuthenticatorConfig())), context);
+    HomeIdpDiscoverer(AuthenticationFlowContext context, Users users) {
+        this(users, new DomainExtractor(new HomeIdpDiscoveryConfig(context.getAuthenticatorConfig())), context);
     }
 
-    private HomeIdpDiscoverer(DomainExtractor domainExtractor, AuthenticationFlowContext context) {
+    private HomeIdpDiscoverer(Users users, DomainExtractor domainExtractor, AuthenticationFlowContext context) {
+        this.users = users;
         this.domainExtractor = domainExtractor;
         this.context = context;
     }
@@ -41,7 +39,7 @@ final class HomeIdpDiscoverer {
         List<IdentityProviderModel> homeIdps = new ArrayList<>();
 
         final Optional<Domain> emailDomain;
-        UserModel user = context.getUser();
+        UserModel user = users.lookupBy(username);
         if (user == null) {
             LOG.tracef("No user found in AuthenticationFlowContext. Extracting domain from provided username '%s'.",
                 username);

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
@@ -11,10 +11,8 @@ import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.managers.AuthenticationManager;
 
 import java.util.List;
@@ -90,8 +88,6 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
     }
 
     private String setUserInContext(AuthenticationFlowContext context, String username) {
-        context.clearUser();
-
         username = trimToNull(username);
 
         if (username == null) {
@@ -106,18 +102,6 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
         context.getEvent().detail(Details.USERNAME, username);
         context.getAuthenticationSession().setAuthNote(ATTEMPTED_USERNAME, username);
         context.getAuthenticationSession().setClientNote(LOGIN_HINT_PARAM, username);
-
-        try {
-            UserModel user = KeycloakModelUtils.findUserByNameOrEmail(context.getSession(), context.getRealm(),
-                username);
-            if (user != null) {
-                LOG.tracef("Setting user '%s' in context", user.getId());
-                context.setUser(user);
-            }
-        } catch (ModelDuplicateException ex) {
-            LOG.warnf(ex, "Could not uniquely identify the user. Multiple users with name or email '%s' found.",
-                username);
-        }
 
         return username;
     }

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/Users.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/Users.java
@@ -1,0 +1,29 @@
+package de.sventorben.keycloak.authentication.hidpd;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+
+final class Users {
+
+    private static final Logger LOG = Logger.getLogger(Users.class);
+
+    private final AuthenticationFlowContext context;
+
+    Users(AuthenticationFlowContext context) {
+        this.context = context;
+    }
+
+    UserModel lookupBy(String username) {
+        UserModel user = null;
+        try {
+            user = KeycloakModelUtils.findUserByNameOrEmail(context.getSession(), context.getRealm(), username);
+        } catch (ModelDuplicateException ex) {
+            LOG.warnf(ex, "Could not uniquely identify the user. Multiple users with name or email '%s' found.", username);
+        }
+        return user;
+    }
+
+}

--- a/src/test/java/de/sventorben/keycloak/authentication/HomeIdpDiscoveryIT.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/HomeIdpDiscoveryIT.java
@@ -274,6 +274,92 @@ class HomeIdpDiscoveryIT {
     }
 
     @Nested
+    @DisplayName("GH-251: Given local user without any forwarding rules")
+    class GivenLocalUser {
+
+        private String username = "test6";
+
+        @BeforeEach
+        public void setUp() {
+            accountConsolePage().signIn();
+            testRealmLoginPage().signIn(username);
+        }
+
+        @Test
+        @DisplayName("then do not redirect")
+        public void willNotRedirectToIdp() {
+            assertNotRedirected();
+        }
+
+        @Test
+        @DisplayName("then do not show invalid user message")
+        public void noInvalidUserMessage() {
+            testRealmLoginPage().assertNoInvalidUserMessage();
+        }
+
+        @Test
+        @DisplayName("then ask for username")
+        public void askForUsername() {
+            testRealmLoginPage().assertUsernameFieldIsDisplayed();
+        }
+
+        @Test
+        @DisplayName("then prefill username field")
+        public void prefilLUsername() {
+            testRealmLoginPage().assertUsernameFieldIsPrefilledWith(username);
+        }
+
+        @Test
+        @DisplayName("then ask for password")
+        public void willAskForPassword() {
+            testRealmLoginPage().assertPasswordFieldIsDisplayed();
+        }
+    }
+
+    @Nested
+    @DisplayName("GH-251: Given non-existing user")
+    class GivenNonExistingUser {
+
+        private String username = "does not exist";
+
+        @BeforeEach
+        public void setUp() {
+            accountConsolePage().signIn();
+            testRealmLoginPage().signIn(username);
+        }
+
+        @Test
+        @DisplayName("then do not redirect")
+        public void willNotRedirectToIdp() {
+            assertNotRedirected();
+        }
+
+        @Test
+        @DisplayName("then do not show invalid user message")
+        public void noInvalidUserMessage() {
+            testRealmLoginPage().assertNoInvalidUserMessage();
+        }
+
+        @Test
+        @DisplayName("then ask for username")
+        public void askForUsername() {
+            testRealmLoginPage().assertUsernameFieldIsDisplayed();
+        }
+
+        @Test
+        @DisplayName("then prefill username field")
+        public void prefilLUsername() {
+            testRealmLoginPage().assertUsernameFieldIsPrefilledWith(username);
+        }
+
+        @Test
+        @DisplayName("then ask for password")
+        public void willAskForPassword() {
+            testRealmLoginPage().assertPasswordFieldIsDisplayed();
+        }
+    }
+
+    @Nested
     @DisplayName("Given user is linked to an IdP already")
     class GivenUserHasIdpLinkConfigured {
 
@@ -287,13 +373,37 @@ class HomeIdpDiscoveryIT {
             public void setUp() {
                 authenticatorConfig.disableForwarding();
                 accountConsolePage().signIn();
+                testRealmLoginPage().signIn(username);
             }
 
             @Test
             @DisplayName("then do not redirect")
             public void willNotRedirectToIdp() {
-                testRealmLoginPage().signIn(username);
                 assertNotRedirected();
+            }
+
+            @Test
+            @DisplayName("GH-251: then do not show invalid user message")
+            public void noInvalidUserMessage() {
+                testRealmLoginPage().assertNoInvalidUserMessage();
+            }
+
+            @Test
+            @DisplayName("GH-251: then ask for username")
+            public void askForUsername() {
+                testRealmLoginPage().assertUsernameFieldIsDisplayed();
+            }
+
+            @Test
+            @DisplayName("GH-251: then prefill username field")
+            public void prefilLUsername() {
+                testRealmLoginPage().assertUsernameFieldIsPrefilledWith(username);
+            }
+
+            @Test
+            @DisplayName("GH-251: then ask for password")
+            public void willAskForPassword() {
+                testRealmLoginPage().assertPasswordFieldIsDisplayed();
             }
         }
 
@@ -355,7 +465,7 @@ class HomeIdpDiscoveryIT {
 
     private void assertNotRedirected() {
         assertRedirectedTo(
-            KEYCLOAK_BASE_URL + "/realms/test-realm/login-actions/authenticate?client_id=account-console");
+            KEYCLOAK_BASE_URL + "/realms/test-realm/login-actions/authenticate");
     }
 
     private void assertRedirectedTo(String url) {

--- a/src/test/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscovererTest.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscovererTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.UserModel;
-import org.mockito.InjectMocks;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,8 +25,7 @@ class HomeIdpDiscovererTest {
     @BeforeEach
     void setUp() {
         when(context.getRealm()).thenReturn(mock(RealmModel.class));
-        when(context.getUser()).thenReturn(mock(UserModel.class));
-        cut = new HomeIdpDiscoverer(context);
+        cut = new HomeIdpDiscoverer(context, mock(Users.class));
     }
 
     @Test

--- a/src/test/resources/test-realm.json
+++ b/src/test/resources/test-realm.json
@@ -196,6 +196,26 @@
       "realmRoles" : [ "default-roles-test-realm" ],
       "notBefore" : 0,
       "groups" : [ ]
+  }, {
+      "id" : "139020a3-4459-43b1-a92f-d90e5cf093a6",
+      "createdTimestamp" : 1632070461116,
+      "username" : "test6",
+      "enabled" : true,
+      "totp" : false,
+      "email" : "test6@local.local",
+      "emailVerified" : true,
+      "credentials" : [ {
+          "id" : "b7a13463-c361-4893-bae2-a7c28723ba46",
+          "type" : "password",
+          "createdDate" : 1632070469930,
+          "secretData" : "{\"value\":\"f0KV+30selJs9QbGBR/Yl62Eu0fRP2EUudbUEYMLgEdeXrRMKZFMtY3OlfG3W9a6ygNflxj9ysUv4j/RwnMN8g==\",\"salt\":\"ZAaXBhufypfX/dSuy9+Pdg==\",\"additionalParameters\":{}}",
+          "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+      } ],
+      "disableableCredentialTypes" : [ ],
+      "requiredActions" : [ ],
+      "realmRoles" : [ "default-roles-test-realm" ],
+      "notBefore" : 0,
+      "groups" : [ ]
   } ],
   "scopeMappings": [
     {
@@ -1721,6 +1741,24 @@
       ]
     },
     {
+      "id": "f8d96ad1-d613-4e49-89d4-cd0adca91291",
+      "alias": "Username & Password",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
       "id": "9e73fe2a-e76e-4ec5-ab63-ef507539e785",
       "alias": "flow-with-alternatives",
       "description": "",
@@ -1858,6 +1896,14 @@
           "flowAlias": "discover home idp",
           "userSetupAllowed": false,
           "autheticatorFlow": true
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 2,
+          "autheticatorFlow": true,
+          "flowAlias": "Username & Password",
+          "userSetupAllowed": false
         }
       ]
     },


### PR DESCRIPTION
The HomeIdpDiscoveryAuthenticator sets the user in the auth context in order to function properly. However, it doesn't clear it in case it "fails", meaning the next authenticator will be aware of the user.

This is problematic when a username/email doesn't match an idp, and keycloak redirects to the username password form. Indeed, the latter behaves differently whether the user is known or not (showing/hiding the email field). Without clearing the user from the auth context, we basically leak information on which user exists.

This fix should ensure the username/password form always shows the email field by not setting the user in the auth context at all.

Closes #251