### PR TITLE
Revert "chore(deps-dev): bump version.selenium from 4.15.0 to 4.16.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
         <version.mockito>5.8.0</version.mockito>
         <version.testcontainers>1.19.3</version.testcontainers>
-        <version.selenium>4.16.1</version.selenium>
+        <version.selenium>4.15.0</version.selenium>
     </properties>
 
     <build>


### PR DESCRIPTION
Reverts sventorben/keycloak-home-idp-discovery#284

Made the builds unstable and caused timeout issue when starting the selenium container.