### PR TITLE
Ask for username on reauthentication when no session present

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/AuthenticationChallenge.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/AuthenticationChallenge.java
@@ -32,11 +32,13 @@ final class AuthenticationChallenge {
 
         String rememberMeUsername = rememberMe.getUserName();
 
+        Response challengeResponse;
         if (reauthentication.required() && context.getUser() != null) {
             String attribute = Optional.ofNullable(context.getAuthenticatorConfig())
                 .map(it -> it.getConfig().getOrDefault("userAttribute", "email").trim())
                 .orElse("email");
             formData.add(AuthenticationManager.FORM_USERNAME, context.getUser().getFirstAttribute(attribute));
+            challengeResponse = loginForm.createWithSignInButtonOnly(formData);
         } else {
             if (loginHintUsername != null || rememberMeUsername != null) {
                 if (loginHintUsername != null) {
@@ -46,12 +48,6 @@ final class AuthenticationChallenge {
                     formData.add("rememberMe", "on");
                 }
             }
-        }
-
-        Response challengeResponse;
-        if (reauthentication.required()) {
-            challengeResponse = loginForm.createWithSignInButtonOnly(formData);
-        } else {
             challengeResponse = loginForm.create(formData);
         }
 

--- a/src/test/java/de/sventorben/keycloak/authentication/HomeIdpDiscoveryIT.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/HomeIdpDiscoveryIT.java
@@ -434,6 +434,29 @@ class HomeIdpDiscoveryIT {
     }
 
     @Nested
+    @DisplayName("GH-475: Given no session and prompt=login")
+    class GivenNoSessionAndPromptLogin {
+
+        @BeforeEach
+        public void setUp() {
+            upstreamIdpMock().redirectToDownstreamWithPromptLogin("test");
+        }
+
+        @Test
+        @DisplayName("then show username form field")
+        public void thenShowUsernameFormField() {
+            testRealmLoginPage().assertUsernameFieldIsDisplayed();
+        }
+
+        @Test
+        @DisplayName("then username form field is empty")
+        public void thenUsernameFormFieldIsEmpty() {
+            testRealmLoginPage().assertUsernameFieldIsPrefilledWith("");
+        }
+
+    }
+
+    @Nested
     @DisplayName("Given user is linked to an IdP already")
     class GivenUserHasIdpLinkConfigured {
 

--- a/src/test/java/de/sventorben/keycloak/authentication/pages/UpstreamIdpMock.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/pages/UpstreamIdpMock.java
@@ -22,4 +22,10 @@ public class UpstreamIdpMock {
         webDriver.navigate().to(keycloakBaseUrl + url);
     }
 
+    public void redirectToDownstreamWithPromptLogin(String clientId) {
+        String url = "/realms/test-realm/protocol/openid-connect/auth?client_id=" + clientId + "&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Frealms%2Ftest-realm%2Faccount%2F&response_mode=fragment&response_type=code&scope=openid";
+        url += "&prompt=login";
+        webDriver.navigate().to(keycloakBaseUrl + url);
+    }
+
 }


### PR DESCRIPTION
When a client or federating IdP forces login (or reauthentication), but no user exists in the current session or no session is present at all, ask for the username on the login page.

Fixes #475