### PR TITLE
Forward Disabled Users to Their Home IdP

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/email/DomainExtractor.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/email/DomainExtractor.java
@@ -16,10 +16,6 @@ final class DomainExtractor {
     }
 
     Optional<Domain> extractFrom(UserModel user) {
-        if (!user.isEnabled()) {
-            LOG.warnf("User '%s' not enabled", user.getId());
-            return Optional.empty();
-        }
         String userAttribute = user.getFirstAttribute(config.userAttribute());
         if (userAttribute == null) {
             LOG.warnf("Could not find user attribute '%s' for user '%s'", config.userAttribute(), user.getId());


### PR DESCRIPTION
This change ensures that disabled users are redirected to their home IdP, bypassing execution of subsequent authenticators. The post-broker login flow and Keycloak's default behavior will now handle these cases, showing error messages appropriately.

Breaking change: Disabled users are no longer processed by subsequent authenticators. This behavior avoids unexpected errors and ensures a more consistent and predictable user experience.

This approach was implemented to delegate error handling to Keycloak's native logic, improving maintainability and avoiding custom error flows.

Fixes #399