### PR TITLE
fix: keep SSO session when an organization scope is requested

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpAuthenticationFlowContext.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpAuthenticationFlowContext.java
@@ -16,6 +16,7 @@ final class HomeIdpAuthenticationFlowContext {
     private BaseUriLoginFormsProvider loginFormsProvider;
     private LoginForm loginForm;
     private Reauthentication reauthentication;
+    private SingleSignOn singleSignOn;
 
     HomeIdpAuthenticationFlowContext(AuthenticationFlowContext context) {
         this.context = context;
@@ -89,5 +90,12 @@ final class HomeIdpAuthenticationFlowContext {
             reauthentication = new Reauthentication(context);
         }
         return reauthentication;
+    }
+
+    SingleSignOn singleSignOn() {
+        if (singleSignOn == null) {
+            singleSignOn = new SingleSignOn(context);
+        }
+        return singleSignOn;
     }
 }

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/HomeIdpDiscoveryAuthenticator.java
@@ -32,6 +32,18 @@ final class HomeIdpDiscoveryAuthenticator extends AbstractUsernameFormAuthentica
     @Override
     public void authenticate(AuthenticationFlowContext authenticationFlowContext) {
         HomeIdpAuthenticationFlowContext context = new HomeIdpAuthenticationFlowContext(authenticationFlowContext);
+
+        if (context.singleSignOn().established()) {
+            // Since Keycloak 26.1 the cookie authenticator no longer completes the flow when an
+            // organization scope is requested; it defers to the organization authenticator, which
+            // resolves the organization and only then succeeds. Flows built around this
+            // authenticator have no such execution, so without this the user would be challenged
+            // again despite holding a valid session. See issue #533.
+            LOG.debugf("User is already authenticated via SSO, skipping discovery");
+            authenticationFlowContext.success();
+            return;
+        }
+
         if (context.loginPage().shouldByPass()) {
             String usernameHint = usernameHint(authenticationFlowContext, context);
             if (usernameHint != null) {

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/SingleSignOn.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/SingleSignOn.java
@@ -1,0 +1,26 @@
+package de.sventorben.keycloak.authentication.hidpd;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticatorUtil;
+
+final class SingleSignOn {
+
+    private final AuthenticationFlowContext context;
+
+    SingleSignOn(AuthenticationFlowContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Whether the cookie authenticator has already authenticated the user for this request.
+     * <p>
+     * Keycloak only sets the {@code SSO_AUTH} note on the fully successful cookie-only path, right
+     * after attaching the user session. Forced re-authentication, step-up and forked flows all take
+     * different branches that leave the note unset, so the note is a reliable signal that nothing
+     * further is required from the user.
+     */
+    boolean established() {
+        return context.getUser() != null
+            && AuthenticatorUtil.isSSOAuthentication(context.getAuthenticationSession());
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/authentication/hidpd/SingleSignOnTest.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/hidpd/SingleSignOnTest.java
@@ -1,0 +1,58 @@
+package de.sventorben.keycloak.authentication.hidpd;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class SingleSignOnTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    AuthenticationFlowContext context;
+
+    @Mock
+    UserModel user;
+
+    @InjectMocks
+    SingleSignOn cut;
+
+    @Test
+    @DisplayName("Given a user and the SSO auth note, then SSO is established")
+    void givenUserAndSsoAuthNoteThenEstablished() {
+        given(context.getUser()).willReturn(user);
+        given(context.getAuthenticationSession().getAuthNote(AuthenticationManager.SSO_AUTH))
+            .willReturn("true");
+
+        assertThat(cut.established()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Given no user, then SSO is not established")
+    void givenNoUserThenNotEstablished() {
+        given(context.getUser()).willReturn(null);
+
+        assertThat(cut.established()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Given a user but no SSO auth note, then SSO is not established")
+    void givenNoSsoAuthNoteThenNotEstablished() {
+        // Forced re-authentication, step-up and forked flows all leave the note unset, so the user
+        // must still be challenged.
+        given(context.getUser()).willReturn(user);
+        given(context.getAuthenticationSession().getAuthNote(AuthenticationManager.SSO_AUTH))
+            .willReturn(null);
+
+        assertThat(cut.established()).isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #533

## Problem

Since Keycloak 26.1.0, `CookieAuthenticator` no longer completes the flow on a cookie-only authentication when organizations are enabled and the client requests an organization scope:

```java
 authSession.setAuthNote(AuthenticationManager.SSO_AUTH, "true");
 context.attachUserSession(authResult.getSession());
-context.success();
+if (isOrganizationContext(context)) {
+    // if re-authenticating in the scope of an organization, an organization must be resolved prior to authenticating the user
+    context.attempted();
+} else {
+    context.success();
+}
```

The cookie is valid, the user is set and the user session is attached — but completion is deferred to `OrganizationAuthenticator`, which resolves the organization and only then calls `success()`.

Flows built around this extension have no such execution. Nothing calls `success()`, so the flow falls through to the username form and the user is challenged again despite holding a valid session. This is what #533 describes as being logged out on page reload; the session is never actually lost, which is why re-entering the email address returns the user to the application without another trip to the IdP.

It also explains the read-only first form in the issue: `CookieAuthenticator` has already called `context.setUser(...)`, so Keycloak renders the username page in known-user mode.

This matches the reporter's observation that 26.0.8 works and 26.1.1 does not — `isOrganizationContext` did not exist in 26.0.8. The behaviour is unchanged as of 26.7.0.

## Fix

Complete the authentication when the cookie authenticator has already established the session:

```java
if (context.singleSignOn().established()) {
    LOG.debugf("User is already authenticated via SSO, skipping discovery");
    authenticationFlowContext.success();
    return;
}
```

Keycloak sets `SSO_AUTH` only on the fully successful cookie-only path. Forced re-authentication (`prompt=login` / `max_age`) sets `FORCED_REAUTHENTICATION` instead, and step-up and forked flows take branches that leave the note unset — so the note cannot misfire on a case where the user genuinely still needs to authenticate.

The change is inert on flows without an organization scope: there the cookie authenticator still succeeds and this authenticator is never reached.

## Compatibility

No organization APIs are used, so the fix is safe across the whole supported matrix down to KC 21. `RealmModel.isOrganizationsEnabled()` does not exist before 26.0 and `OrganizationScope.valueOfScope` changed signature in 26.1, whereas `AuthenticatorUtil.isSSOAuthentication` is present as far back as 21.0.2. On KC < 26.1 the new branch is simply unreachable.

## Testing

`SingleSignOnTest` covers the predicate; full unit suite passes (50 tests).

Not covered: an integration test reproducing the reload against a realm with organizations enabled and an organization scope on the client. Worth adding to `HomeIdpDiscoveryIT`, but larger than this fix.

## Follow-ups (out of scope here)

- The orgs discoverers never set `OrganizationModel.ORGANIZATION_ATTRIBUTE`, so the `organization` claim is resolved by scope fallback rather than from the organization actually discovered. Worth verifying against a multi-organization user.
- Upstream: `CookieAuthenticator` assumes an organization-resolving execution exists downstream, which breaks any third-party flow that replaces `OrganizationAuthenticator`. Gating the `attempted()` on the flow actually containing such an execution would fix this for all extensions at once.
