### PR TITLE
fix: record discovered organization for the organization claim

### DIFF
--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/SelectedOrganization.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/SelectedOrganization.java
@@ -1,0 +1,42 @@
+package de.sventorben.keycloak.authentication.hidpd.discovery.orgs;
+
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+/**
+ * Records the organization that discovery has narrowed down to, so that it ends up in the tokens.
+ * <p>
+ * Keycloak copies client notes from the authentication session onto the client session, where
+ * {@code OrganizationScope.ANY} reads them. Without such a note, a {@code scope=organization}
+ * request made by a user who belongs to more than one organization yields no organization claim at
+ * all, because Keycloak cannot tell which of the memberships applies. The native organization flow
+ * asks the user to pick one; here discovery has already determined it from the email domain.
+ * <p>
+ * Scopes {@code organization:*} and {@code organization:<alias>} resolve their organizations
+ * without consulting this note and are unaffected.
+ *
+ * @implNote Internal to this extension. Not part of the public API.
+ */
+public final class SelectedOrganization {
+
+    private static final Logger LOG = Logger.getLogger(SelectedOrganization.class);
+
+    private SelectedOrganization() {
+    }
+
+    public static void remember(AuthenticationFlowContext context, OrganizationModel organization) {
+        if (organization == null) {
+            return;
+        }
+
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        if (authSession == null) {
+            return;
+        }
+
+        LOG.tracef("Remembering organization '%s' as the one discovery resolved", organization.getId());
+        authSession.setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, organization.getId());
+    }
+}

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/domainhint/OrgsDomainDiscoverer.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/domainhint/OrgsDomainDiscoverer.java
@@ -1,5 +1,6 @@
 package de.sventorben.keycloak.authentication.hidpd.discovery.orgs.domainhint;
 
+import de.sventorben.keycloak.authentication.hidpd.discovery.orgs.SelectedOrganization;
 import de.sventorben.keycloak.authentication.hidpd.discovery.spi.HomeIdpDiscoverer;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
@@ -30,6 +31,7 @@ final class OrgsDomainDiscoverer implements HomeIdpDiscoverer {
 
         OrganizationModel org = orgProvider.getByDomainName(domain);
         if (org != null) {
+            SelectedOrganization.remember(context, org);
             return org.getIdentityProviders()
                 .filter(IdentityProviderModel::isEnabled)
                 .collect(Collectors.toList());

--- a/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/email/OrgsIdentityProviders.java
+++ b/src/main/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/email/OrgsIdentityProviders.java
@@ -2,6 +2,7 @@ package de.sventorben.keycloak.authentication.hidpd.discovery.orgs.email;
 
 import de.sventorben.keycloak.authentication.hidpd.discovery.email.Domain;
 import de.sventorben.keycloak.authentication.hidpd.discovery.email.IdentityProviders;
+import de.sventorben.keycloak.authentication.hidpd.discovery.orgs.SelectedOrganization;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.OrganizationDomainModel;
@@ -48,6 +49,7 @@ final class OrgsIdentityProviders implements IdentityProviders {
                     .filter(it -> domain.getRawValue().equalsIgnoreCase(it.getName()))
                     .anyMatch(OrganizationDomainModel::isVerified);
                 if (verified) {
+                    SelectedOrganization.remember(context, org);
                     return org.getIdentityProviders()
                         .filter(IdentityProviderModel::isEnabled)
                         // TODO: Filter based on domain - should only be one

--- a/src/test/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/SelectedOrganizationTest.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/hidpd/discovery/orgs/SelectedOrganizationTest.java
@@ -1,0 +1,58 @@
+package de.sventorben.keycloak.authentication.hidpd.discovery.orgs;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class SelectedOrganizationTest {
+
+    @Mock
+    AuthenticationFlowContext context;
+
+    @Mock
+    AuthenticationSessionModel authSession;
+
+    @Mock
+    OrganizationModel organization;
+
+    @Test
+    @DisplayName("Given an organization, then it is remembered as a client note")
+    void givenOrganizationThenRememberedAsClientNote() {
+        given(context.getAuthenticationSession()).willReturn(authSession);
+        given(organization.getId()).willReturn("org-id");
+
+        SelectedOrganization.remember(context, organization);
+
+        verify(authSession).setClientNote(OrganizationModel.ORGANIZATION_ATTRIBUTE, "org-id");
+    }
+
+    @Test
+    @DisplayName("Given no organization, then nothing is remembered")
+    void givenNoOrganizationThenNothingRemembered() {
+        SelectedOrganization.remember(context, null);
+
+        verifyNoInteractions(context);
+    }
+
+    @Test
+    @DisplayName("Given no authentication session, then nothing is remembered")
+    void givenNoAuthenticationSessionThenNothingRemembered() {
+        given(context.getAuthenticationSession()).willReturn(null);
+
+        SelectedOrganization.remember(context, organization);
+
+        verify(authSession, never()).setClientNote(org.mockito.ArgumentMatchers.anyString(),
+            org.mockito.ArgumentMatchers.anyString());
+    }
+}


### PR DESCRIPTION
Follow-up to #662, independent of it.

## Problem

When a client requests `scope=organization`, Keycloak resolves the claim through `OrganizationScope.ANY`:

```java
List<OrganizationModel> organizations = getProvider(session).getByMember(user)
        .filter(OrganizationModel::isEnabled).toList();

if (organizations.size() == 1) {
    return organizations.stream();
}

// ...
String orgId = clientSession.getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);

if (orgId == null) {
    return Stream.empty();
}
```

A user in exactly one organization resolves fine. A user in **more than one** organization falls through to the `ORGANIZATION_ATTRIBUTE` note on the client session, and an absent note yields an empty stream — `OrganizationMembershipMapper.setClaim` then writes no claim at all.

The native organization flow sets that note after asking the user to select an organization (`OrganizationAuthenticator.resolveOrganization`). Flows built around this extension never do, so multi-organization users silently received no `organization` claim — even though discovery had already determined which organization the email domain belongs to. This is the configuration described in #533 by `toni1991`.

## Fix

Record the organization as a client note on the authentication session when discovery resolves one by domain, in `OrgsIdentityProviders.withMatchingDomain` and `OrgsDomainDiscoverer.discoverForUser`. Keycloak transfers authentication-session client notes onto the client session verbatim (`TokenManager#attachAuthenticationSession`), which is where the resolver reads them.

## Scope of the change

- `organization:*` (`ALL`) and `organization:<alias>` (`SPECIFIC`) resolve their organizations from the scope itself and never consult the note — unaffected.
- `organization` (`ANY`) with a single-organization user already worked — unaffected.
- `organization` (`ANY`) with a multi-organization user is the case this fixes.
- A note pointing at an organization the user is not a member of is filtered out by the resolver, so the change cannot widen access.

## Caveat worth reviewing

`withMatchingDomain` runs before the linked-identity-provider preference is applied, so the domain-matched organization is recorded even when the user is subsequently forwarded to a linked IdP owned by a *different* organization. The email domain is what this extension treats as the user's home, and it is the only single-organization signal available at that point — but if you would rather the claim follow the IdP that was actually used, that needs the discoverer SPI to carry the organization back to the authenticator, which is a larger change.

## Testing

`SelectedOrganizationTest` covers the note-writing behaviour; full unit suite passes (50 tests).

Not covered: an integration test asserting the `organization` claim for a user in multiple organizations under `scope=organization`. That is the test that would actually pin this behaviour down, and it needs an organizations-enabled IT fixture that does not exist yet.
