### PR TITLE
test: wait for navigation before asserting on the browser URL

### DIFF
--- a/src/test/java/de/sventorben/keycloak/authentication/HomeIdpDiscoveryIT.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/HomeIdpDiscoveryIT.java
@@ -2,6 +2,7 @@ package de.sventorben.keycloak.authentication;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import de.sventorben.keycloak.authentication.pages.AccountConsolePage;
+import de.sventorben.keycloak.authentication.pages.Navigation;
 import de.sventorben.keycloak.authentication.pages.SelectIdpPage;
 import de.sventorben.keycloak.authentication.pages.TestRealmLoginPage;
 import de.sventorben.keycloak.authentication.pages.UpstreamIdpMock;
@@ -295,7 +296,11 @@ class HomeIdpDiscoveryIT {
                 public void whenRestartingFlow() {
                     upstreamIdpMock().redirectToDownstreamWithLoginHint("test", null);
                     testRealmLoginPage().signIn(usernameWithMultipleIdps);
-                    String restartUrl = webDriver.getCurrentUrl().replace("/authenticate", "/restart") + "&skip_logout=false";
+                    String authenticateUrl = webDriver.getCurrentUrl();
+                    // Fail loudly rather than silently navigating to an unchanged URL if the sign-in
+                    // navigation has not completed.
+                    assertThat(authenticateUrl).contains("/authenticate");
+                    String restartUrl = authenticateUrl.replace("/authenticate", "/restart") + "&skip_logout=false";
                     webDriver.navigate().to(restartUrl);
 
                     testRealmLoginPage().assertUsernameFieldIsDisplayed();
@@ -452,7 +457,7 @@ class HomeIdpDiscoveryIT {
         @Test
         @DisplayName("then pass login_hint parameter to downstream IdP")
         public void willForwardLoginHint() {
-            assertThat(webDriver.getCurrentUrl()).contains("&login_hint=someone%40example.com&");
+            assertUrlContains("&login_hint=someone%40example.com&");
         }
     }
 
@@ -548,7 +553,7 @@ class HomeIdpDiscoveryIT {
             @DisplayName("then pass login_hint parameter to downstream IdP")
             public void willForwardLoginHint() {
                 testRealmLoginPage().signIn(username);
-                assertThat(webDriver.getCurrentUrl()).contains("&login_hint=idp-test5-username&");
+                assertUrlContains("&login_hint=idp-test5-username&");
             }
         }
     }
@@ -580,7 +585,12 @@ class HomeIdpDiscoveryIT {
 
     private void assertRedirectedToIdp(String idpAlias) {
         assertRedirectedTo(KEYCLOAK_BASE_URL + "/realms/idp/protocol/openid-connect/auth");
-        assertThat(webDriver.getCurrentUrl()).contains("broker%2F" + idpAlias + "%2F");
+        assertUrlContains("broker%2F" + idpAlias + "%2F");
+    }
+
+    private void assertUrlContains(String fragment) {
+        Navigation.awaitUrlContaining(webDriver, fragment);
+        assertThat(webDriver.getCurrentUrl()).contains(fragment);
     }
 
     private void assertNotRedirected() {

--- a/src/test/java/de/sventorben/keycloak/authentication/pages/Navigation.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/pages/Navigation.java
@@ -1,0 +1,54 @@
+package de.sventorben.keycloak.authentication.pages;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Synchronisation helpers for page navigation.
+ * <p>
+ * Selenium returns from a click as soon as the command has been dispatched, not once the resulting
+ * page has loaded, and an implicit wait only covers element lookups -- it never applies to
+ * {@code getCurrentUrl()}. Anything that inspects the URL straight after an action therefore has to
+ * wait for the navigation explicitly, or it observes the page the browser is about to leave.
+ */
+public final class Navigation {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+    private Navigation() {
+    }
+
+    public static void awaitUrlStartingWith(WebDriver webDriver, String prefix) {
+        await(webDriver).until(driver -> {
+            String currentUrl = driver.getCurrentUrl();
+            return currentUrl != null && currentUrl.startsWith(prefix);
+        });
+    }
+
+    public static void awaitUrlContaining(WebDriver webDriver, String fragment) {
+        await(webDriver).until(ExpectedConditions.urlContains(fragment));
+    }
+
+    /**
+     * Clicks an element and waits until the browser has actually left the current URL, so that
+     * callers reading the URL afterwards observe the page the click led to.
+     * <p>
+     * Note that {@link ExpectedConditions#stalenessOf} is unsuitable here: elements injected by
+     * {@code PageFactory} are proxies that re-locate themselves on every access and so never go
+     * stale.
+     */
+    public static void clickAndAwaitNavigation(WebDriver webDriver, WebElement element) {
+        String urlBefore = webDriver.getCurrentUrl();
+        element.click();
+        await(webDriver).until(driver -> !Objects.equals(driver.getCurrentUrl(), urlBefore));
+    }
+
+    private static WebDriverWait await(WebDriver webDriver) {
+        return new WebDriverWait(webDriver, TIMEOUT);
+    }
+}

--- a/src/test/java/de/sventorben/keycloak/authentication/pages/SelectIdpPage.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/pages/SelectIdpPage.java
@@ -10,6 +10,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SelectIdpPage {
 
+    private static final String LOGIN_ACTIONS_PATH = "/realms/test-realm/login-actions/authenticate";
+
     private final WebDriver webDriver;
     private final String keycloakBaseUrl;
 
@@ -23,8 +25,8 @@ public class SelectIdpPage {
     }
 
     public void assertOnPage() {
-        assertThat(webDriver.getCurrentUrl()).startsWith(
-            keycloakBaseUrl + "/realms/test-realm/login-actions/authenticate");
+        Navigation.awaitUrlStartingWith(webDriver, keycloakBaseUrl + LOGIN_ACTIONS_PATH);
+        assertThat(webDriver.getCurrentUrl()).startsWith(keycloakBaseUrl + LOGIN_ACTIONS_PATH);
         assertPageTitle();
     }
 
@@ -34,6 +36,6 @@ public class SelectIdpPage {
 
     public void selectIdp(String idpAlias) {
         WebElement idpLoginLink = webDriver.findElements(By.id("social-" + idpAlias)).get(0);
-        idpLoginLink.click();
+        Navigation.clickAndAwaitNavigation(webDriver, idpLoginLink);
     }
 }

--- a/src/test/java/de/sventorben/keycloak/authentication/pages/SelectLoginMethodPage.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/pages/SelectLoginMethodPage.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SelectLoginMethodPage {
 
+    private static final String LOGIN_ACTIONS_PATH = "/realms/test-realm/login-actions/authenticate";
+
     private final WebDriver webDriver;
     private final String keycloakBaseUrl;
 
@@ -26,8 +28,8 @@ public class SelectLoginMethodPage {
         this.webDriver = webDriver;
         this.keycloakBaseUrl = keycloakBaseUrl;
         PageFactory.initElements(webDriver, this);
-        assertThat(webDriver.getCurrentUrl()).startsWith(
-            keycloakBaseUrl + "/realms/test-realm/login-actions/authenticate");
+        Navigation.awaitUrlStartingWith(webDriver, keycloakBaseUrl + LOGIN_ACTIONS_PATH);
+        assertThat(webDriver.getCurrentUrl()).startsWith(keycloakBaseUrl + LOGIN_ACTIONS_PATH);
         assertThat(pageTitle.getText()).isEqualTo("Select login method");
     }
 

--- a/src/test/java/de/sventorben/keycloak/authentication/pages/TestRealmLoginPage.java
+++ b/src/test/java/de/sventorben/keycloak/authentication/pages/TestRealmLoginPage.java
@@ -44,24 +44,22 @@ public class TestRealmLoginPage {
     }
 
     private void waitForLoginPage() {
-        new WebDriverWait(webDriver, Duration.ofSeconds(5))
-            .until((driver) -> {
-                String currentUrl = driver.getCurrentUrl();
-                return currentUrl.startsWith(keycloakBaseUrl + OIDC_AUTH_PATH)
-                    || currentUrl.startsWith(keycloakBaseUrl + LOGIN_ACTIONS_PATH);
-            }
-        );
+        // The URL alone cannot tell us the page has arrived: the browser already sits on the OIDC
+        // auth path before navigating, so a URL check is satisfied on the first poll and returns
+        // while the previous page is still on screen. Wait for the form itself instead.
+        new WebDriverWait(webDriver, Duration.ofSeconds(10))
+            .until(ExpectedConditions.visibilityOf(usernameInput));
     }
 
     public void signIn(String username) {
         new WebDriverWait(webDriver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOf(usernameInput));
         usernameInput.sendKeys(username);
-        signInButton.click();
+        Navigation.clickAndAwaitNavigation(webDriver, signInButton);
     }
 
     public void tryAnotherWay() {
         new WebDriverWait(webDriver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOf(tryAnotherWayLink));
-        tryAnotherWayLink.click();
+        Navigation.clickAndAwaitNavigation(webDriver, tryAnotherWayLink);
     }
 
     public void enableRememberMe() {


### PR DESCRIPTION
Test-only change. No production code is touched.

## The failures are not version specific

From run [29682799964](https://github.com/sventorben/keycloak-home-idp-discovery/actions/runs/29682799964) on the same commit:

| Job | Result |
|---|---|
| `26.5.7` | ✗ |
| `26.6.4` | ✓ |
| `26.7.0` | ✗ |
| `latest` | ✓ |
| `nightly` | ✓ |

A genuine compatibility problem would not skip 26.6.4 and pass on `latest`. This is a race, and which jobs lose it varies per run — hence the "different number and types of errors" each time.

## One root cause

Selenium returns from a click as soon as the command has been dispatched, not once the resulting page has loaded. An implicit wait only covers element lookups; it never applies to `getCurrentUrl()`. So every assertion that reads the URL straight after an action can observe the page the browser is about to leave.

All four failures in that run are that single race:

| Failure | Site | Observed |
|---|---|---|
| `AlternativeMessagesIT…AnotherWayHelpText` | `SelectLoginMethodPage` constructor | asserted `/login-actions/authenticate`, saw `/protocol/openid-connect/auth?…` |
| `showSelectionIfMultipleIdpsMatch` | `SelectIdpPage.assertOnPage()` | same |
| `willForwardLoginHint` | `HomeIdpDiscoveryIT` | asserted `&login_hint=…`, saw the account-console URL before the IdP redirect |
| `whenRestartingFlow` | `HomeIdpDiscoveryIT` | `NoSuchElement` for `input[id='username']`, downstream of the same race |

## Why the existing waits did not catch it

Two things made this look protected when it was not:

1. The page object constructors asserted on the URL with **no wait at all**.
2. `TestRealmLoginPage.waitForLoginPage()` waited for the URL to start with the OIDC auth path **or** the login-actions path. The browser already sits on the former before navigating, so the condition held on the first poll and the wait returned while the previous page was still on screen — a no-op in exactly the case it was meant to guard.

## Changes

- New `Navigation` helper: `awaitUrlStartingWith`, `awaitUrlContaining`, and `clickAndAwaitNavigation`.
- `TestRealmLoginPage.waitForLoginPage()` now waits for the login form to be visible rather than for a URL that is already true.
- Navigating clicks (`signIn`, `tryAnotherWay`, `selectIdp`) wait for the URL to actually change before returning.
- `SelectLoginMethodPage` / `SelectIdpPage` wait for the target URL before asserting it.
- The bare `getCurrentUrl()` assertions in `HomeIdpDiscoveryIT` go through a wait-then-assert helper.
- `whenRestartingFlow` asserts that the current URL really contains `/authenticate` before deriving the restart URL. Previously, when the race hit, that `replace` silently matched nothing and the test navigated to an unchanged URL, surfacing much later as a confusing `NoSuchElement`.

`clickAndAwaitNavigation` waits on a URL change rather than `ExpectedConditions.stalenessOf`, because `PageFactory` injects proxies that re-locate themselves on every access and therefore never go stale.

## Verification

Compiles; unit tests unaffected. **I have not been able to run the integration suite against this change** — CI is the first real exercise of it. Since the bug is a race, a single green run is weak evidence: worth re-running the workflow a couple of times before concluding it is fixed.

## Separate observation, not addressed here

The run shows failsafe rerun output (`Run 1: … Run 2: PASS`), but there is no `rerunFailingTestsCount` in `pom.xml`, the workflows or the test resources — and tests that passed on rerun still failed the build. Normally a passing rerun is reported as a flake and does not fail the build. Worth understanding separately; reruns would mask races rather than fix them, so the waits are worth having either way.
