### PR TITLE
chore(release): Prepare next version after release 26.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.sventorben.keycloak</groupId>
     <artifactId>keycloak-home-idp-discovery</artifactId>
-    <version>26.2.2</version>
+    <version>26.2.3-SNAPSHOT</version>
 
     <name>Keycloak: Home IdP Discovery</name>
     <description>A Keycloak authenticator to redirect users to their home IdP</description>
@@ -28,7 +28,7 @@
         <developerConnection>scm:git:https://github.com/sventorben/keycloak-home-idp-discovery.git
         </developerConnection>
         <url>https://github.com/sventorben/keycloak-home-idp-discovery.git</url>
-        <tag>v26.2.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>de.sventorben.keycloak</groupId>
     <artifactId>keycloak-home-idp-discovery</artifactId>
-    <version>26.2.2-SNAPSHOT</version>
+    <version>26.2.2</version>
 
     <name>Keycloak: Home IdP Discovery</name>
     <description>A Keycloak authenticator to redirect users to their home IdP</description>
@@ -28,7 +28,7 @@
         <developerConnection>scm:git:https://github.com/sventorben/keycloak-home-idp-discovery.git
         </developerConnection>
         <url>https://github.com/sventorben/keycloak-home-idp-discovery.git</url>
-        <tag>HEAD</tag>
+        <tag>v26.2.2</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Prepares the next development iteration after release 26.2.2 (pom `26.2.2-SNAPSHOT` → `26.2.3-SNAPSHOT`).

The branch was pushed by the release workflow, but the `Create Pull Request` step failed with `Resource not accessible by integration` and the pull request was never opened. Raising it manually; the commits are exactly what the workflow produced.

The underlying permissions gap is fixed separately.