### PR TITLE
fix(ci): grant the release job permission to open its pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # An explicit permissions block is exhaustive: every scope not listed here is denied, even
+    # those the repository default would otherwise grant.
     permissions:
-      contents: write       # create the GitHub Release / push tag
+      contents: write        # create the GitHub Release / push tag
       packages: write        # publish to GitHub Packages
       id-token: write        # build-provenance attestation
       attestations: write    # build-provenance attestation
+      pull-requests: write   # open the next-development-iteration PR
 
     steps:
     - name: Checkout


### PR DESCRIPTION
The v26.2.2 release ([run 29684698538](https://github.com/sventorben/keycloak-home-idp-discovery/actions/runs/29684698538)) published everything correctly — tag, GitHub Release with `jar` + `SHA256SUMS` + `bom.json`, GitHub Packages, provenance attestation — and then failed on the final step:

```
* [new branch]      release/26.2.2 -> release/26.2.2
Attempting creation of pull request
##[error]Resource not accessible by integration
```

The branch was pushed; only the pull request was never opened, leaving the version bump stranded. (Raised manually as #665.)

## Cause

Before `5491a45` the release job had **no `permissions:` block**, so it inherited the repository default — which is `write` and includes `pull-requests: write`. That is why `release/26.2.0` got its pull request without trouble.

That commit added an explicit block to obtain the scopes the provenance attestation needs:

```yaml
+    permissions:
+      contents: write
+      packages: write
+      id-token: write        # build-provenance attestation
+      attestations: write    # build-provenance attestation
```

An explicit block is **exhaustive** — every scope not listed drops to `none`. Granting `id-token` and `attestations` silently revoked `pull-requests`, and the failure only surfaced at the next release.

Repository settings are not involved: `default_workflow_permissions` is `write` and `can_approve_pull_request_reviews` is `true`.

## Change

Adds `pull-requests: write`, plus a comment recording that the block is exhaustive so the next scope added does not reintroduce this.

The alignment of the `contents:` comment changed by one space to match its neighbours; no other edit.

## Verification

YAML parses; the job resolves to all five scopes. Beyond that this cannot be proven until the next release runs — the failure only appears on `workflow_dispatch` of the release job. Worth watching that final step on the v26.2.3 release specifically.
